### PR TITLE
lambda: implement GetAlias API

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -848,6 +848,17 @@ def update_alias(function, name):
     return jsonify(do_update_alias(arn, name, version, description))
 
 
+@app.route('%s/functions/<function>/aliases/<name>' % PATH_ROOT, methods=['GET'])
+def get_alias(function, name):
+    arn = func_arn(function)
+    if arn not in arn_to_lambda:
+        return error_response('Function not found: %s' % arn, 404, error_type='ResourceNotFoundException')
+    if name not in arn_to_lambda.get(arn).aliases:
+        return error_response('Alias not found: %s' % arn + ':' + name, 404,
+                              error_type='ResourceNotFoundException')
+    return jsonify(arn_to_lambda.get(arn).aliases.get(name))
+
+
 @app.route('%s/functions/<function>/aliases' % PATH_ROOT, methods=['GET'])
 def list_aliases(function):
     arn = func_arn(function)


### PR DESCRIPTION
This API returns the Alias information given the alias name.

https://docs.aws.amazon.com/lambda/latest/dg/API_GetAlias.html

**Please refer to the contribution guidelines in the README when submitting PRs.**
